### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ seneca.act({
 
 By default this library maintains a connection to ElasticSearch using a keepAlive.  If you use this library as part of your own plugin,  depending on the testing library you employ it's possible that your tests never complete because the connection is held open.  To disable the keepAlive, do: 
 
-````json
+````js
 connection:  {
   keepAlive: false,  // NEEDED FOR TESTS ONLY
   sniffInterval: 0   // NEEDED FOR TESTS ONLY

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ By default this library maintains a connection to ElasticSearch using a keepAliv
 ````json
 connection:  {
   keepAlive: false,  // NEEDED FOR TESTS ONLY
+  sniffInterval: 0   // NEEDED FOR TESTS ONLY
 }
 ````
 


### PR DESCRIPTION
So it turns out, we do need to set the sniff interval.  This is actuall defaulted here:

  https://github.com/AdrianRossouw/seneca-elasticsearch/blob/master/elasticsearch.js#L27

And if not set to 0, overrides the keep alive :)
