### PR TITLE
Updates condition for IndexAlreadyExists

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -217,7 +217,7 @@ function search(options) {
       body: body
     }, function(err) {
       // callback with false if the index was not created
-      if(err && /^IndexAlreadyExistsException/m.test(err.message)) {
+      if(err && /IndexAlreadyExistsException/m.test(err.message)) {
         cb(null, {ok: false})
       } else {
         cb(err, {ok: !err})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-elasticsearch",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "elasticsearch plugin for seneca",
   "main": "elasticsearch.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-elasticsearch",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "description": "elasticsearch plugin for seneca",
   "main": "elasticsearch.js",
   "scripts": {


### PR DESCRIPTION
We deployed this plugin yesterday into our staging environment on Heroku.  The first deploy went well, but subsequent deploys started failing, noting that the index we were requesting already existed.  Interesting, given that the plugin correctly handles the 400 returned when an index exists!

After some troubleshooting today, I found that the error returned by the elasticsearch.js plugin is different when running against a remote server vs. a local one.  Here is the error that the test suite encounters when running against a local elastic instance:

``` js
{ 
  status: '400',
  message: 'IndexAlreadyExistsException[[seneca] already exists]',
  stack: undefined 
}
```

And here's what we get when we run against either the Bonsai or SearchBox elasticsearch hosting services:

``` js
{ 
  status: '400',
  message: 'RemoteTransportException[[Mandrill][inet[/X.Y.Z.A:9300]][indices:admin/create]]; nested: IndexAlreadyExistsException[[catalog] already exists]',
  stack: undefined 
}
```

Note: I masked the actual IP address.

I any case, this change fixes the plugin so that this works on both local, and remote elastic instances.
